### PR TITLE
Updated Alert Detail View

### DIFF
--- a/modules/alerts/detail-layout.json
+++ b/modules/alerts/detail-layout.json
@@ -730,7 +730,11 @@
                                                                                                     "campaigns",
                                                                                                     "mitrelink",
                                                                                                     "communications",
-                                                                                                    "warrooms"
+                                                                                                    "warrooms",
+                                                                                                    "mitre_sub_techniques",
+                                                                                                    "mitre_techniques",
+                                                                                                    "mitremitigations",
+                                                                                                    "mitresoftware"
                                                                                                 ],
                                                                                                 "expandableCol": {
                                                                                                     "indicators": {


### PR DESCRIPTION
MITRE modules has been removed from 'Indicators' tab

Unit Test Case:
Validated that MITRE modules are no longer visible under "Indicators" tab