### PR TITLE
bug#0797187 - updated icon for Mitre attack navigation

### DIFF
--- a/views/navigation.json
+++ b/views/navigation.json
@@ -5,7 +5,7 @@
     "config": {
         "navigation": [
             {
-                "icon": "fa fa-tasks",
+                "icon": "icon icon-mitre-attack",
                 "items": [
                     {
                         "icon": "icon icon-groups",


### PR DESCRIPTION
updated icon for Mitre attack navigation

Bug - https://mantis.fortinet.com/bug_view_page.php?bug_id=0797187