### PR TITLE
1293485 Incident to Case change for widget name and display module name

### DIFF
--- a/info.json
+++ b/info.json
@@ -37,7 +37,7 @@
                 "apiName": "alerts"
             },
             "incidents": {
-                "name": "Incidents",
+                "name": "Cases",
                 "apiName": "incidents"
             },
             "mitre_groups": {
@@ -153,7 +153,7 @@
         "widgets": [
             {
                 "apiName": "mitreAttackSpread",
-                "name": "MITRE ATT&CK Alert Incident Spread",
+                "name": "MITRE ATT&CK Alert Case Spread",
                 "version": "1.0.0"
             }
         ]

--- a/widgets/data.json
+++ b/widgets/data.json
@@ -2,7 +2,7 @@
     {
         "name": "mitreAttackSpread",
         "version": "1.0.0",
-        "title": "MITRE ATT&CK Alert Incident Spread",
+        "title": "MITRE ATT&CK Alert Case Spread",
         "install_mode": "rpm",
         "installer_path": "mitreAttackSpread-1.0.0"
     }


### PR DESCRIPTION
1293485 | SP:Mitre Attack Enrichment Framework displays module name as incident instead of case

**Description:**
Made changed in Content prompt of solution pack
=> module incident is changed to case
=> Widget name 'MITRE ATT&CK Alert Incident Spread' is renamed to 'MITRE ATT&CK Alert Case Spread'

**Tested with private zip**

<img width="634" height="347" alt="image" src="https://github.com/user-attachments/assets/859dec52-034e-40a3-8a57-8852ccba2584" />

and 

<img width="566" height="533" alt="image" src="https://github.com/user-attachments/assets/22bfac13-b676-4778-bb45-6b53b8c46322" />
