### PR TITLE
1311623 Fixed linking for mitre techniques and subtechniques

### DIFF
--- a/playbooks/10 - SP - MITRE ATT&CK Enrichment Framework/> Link ATT&CK Technique.json
+++ b/playbooks/10 - SP - MITRE ATT&CK Enrichment Framework/> Link ATT&CK Technique.json
@@ -1,5 +1,4 @@
 {
-    "@context": "\/api\/3\/contexts\/Workflow",
     "@type": "Workflow",
     "triggerLimit": null,
     "name": "> Link ATT&CK Technique",
@@ -418,14 +417,14 @@
     "groups": [],
     "priority": "\/api\/3\/picklists\/2b563c61-ae2c-41c0-a85a-c9709585e3f2",
     "playbookOrigin": "\/api\/3\/picklists\/b6d710a9-a8ec-41ec-8817-fe9fa062fcdd",
-    "isEditable": true,
+    "isEditable": false,
     "uuid": "cfe23919-0766-45ef-bf37-d621f145b8f3",
     "owners": [],
     "isPrivate": false,
     "deletedAt": null,
     "recordTags": [
         "Alert",
-        "Case",
-        "Enrichment"
+        "Enrichment",
+        "Case"
     ]
 }

--- a/playbooks/10 - SP - MITRE ATT&CK Enrichment Framework/> Link ATT&CK Technique.json
+++ b/playbooks/10 - SP - MITRE ATT&CK Enrichment Framework/> Link ATT&CK Technique.json
@@ -1,4 +1,5 @@
 {
+    "@context": "\/api\/3\/contexts\/Workflow",
     "@type": "Workflow",
     "triggerLimit": null,
     "name": "> Link ATT&CK Technique",
@@ -237,7 +238,7 @@
             "name": "Prepare Body for Sub Techniques",
             "description": null,
             "arguments": {
-                "bodyParam": "{ \"mitregroups\": {{vars.groupIRI | string}},\n\"mitretactics\": {{vars.tacticIRI | string}},\n\"mitresoftware\": {{vars.softwareIRI | string}},\n\"mitretechniques\": {{vars.techniqueIRI | string}}, \n\"mitremitigations\": {{vars.mitigationIRI | string}},\"mitresubtechniques\": {{vars.subTechniqueIRI|string}}}"
+                "bodyParam": "{ \"mitregroups\": {{vars.groupIRI | string}},\n\"mitretactics\": {{vars.tacticIRI | string}},\n\"mitresoftware\": {{vars.softwareIRI | string}},\n\"mitre_techniques\": {{vars.techniqueIRI | string}}, \n\"mitremitigations\": {{vars.mitigationIRI | string}},\"mitre_sub_techniques\": {{vars.subTechniqueIRI|string}}}"
             },
             "status": null,
             "top": "570",
@@ -251,7 +252,7 @@
             "name": "Prepare Body for Techniques",
             "description": null,
             "arguments": {
-                "bodyParam": "{ \"mitregroups\": {{vars.groupIRI | string}},\n\"mitretactics\": {{vars.tacticIRI | string}},\n\"mitresoftware\": {{vars.softwareIRI | string}},\n\"mitretechniques\": {{vars.techniqueIRI | string}}, \n\"mitremitigations\": {{vars.mitigationIRI | string}}}"
+                "bodyParam": "{ \"mitregroups\": {{vars.groupIRI | string}},\n\"mitretactics\": {{vars.tacticIRI | string}},\n\"mitresoftware\": {{vars.softwareIRI | string}},\n\"mitre_techniques\": {{vars.techniqueIRI | string}}, \n\"mitremitigations\": {{vars.mitigationIRI | string}}}"
             },
             "status": null,
             "top": "570",
@@ -417,14 +418,14 @@
     "groups": [],
     "priority": "\/api\/3\/picklists\/2b563c61-ae2c-41c0-a85a-c9709585e3f2",
     "playbookOrigin": "\/api\/3\/picklists\/b6d710a9-a8ec-41ec-8817-fe9fa062fcdd",
-    "isEditable": false,
+    "isEditable": true,
     "uuid": "cfe23919-0766-45ef-bf37-d621f145b8f3",
     "owners": [],
     "isPrivate": false,
     "deletedAt": null,
     "recordTags": [
         "Alert",
-        "Enrichment",
-        "Case"
+        "Case",
+        "Enrichment"
     ]
 }


### PR DESCRIPTION
1311623 | Technique and Sub-Technique are not getting linked to Alert / Case Records

Description:
- Playbook [> Link ATT&CK Technique] is not able link techniques and sub-techniques 
- Fixed playbook [> Link ATT&CK Technique]  , step [Prepare Body for Techniques] 

Impact:
Techniques and sub-techniques are getting linked when added to field [Technique ID] in alert module.
Tested with private zip.
<img width="1231" height="439" alt="image" src="https://github.com/user-attachments/assets/a1d57d8f-a235-4303-87a7-165b653a40fe" />
