### PR TITLE
1311623 Fixed linking for mitre techniques and subtechniques

### DIFF
--- a/playbooks/10 - SP - MITRE ATT&CK Enrichment Framework/> Link ATT&CK Technique.json
+++ b/playbooks/10 - SP - MITRE ATT&CK Enrichment Framework/> Link ATT&CK Technique.json
@@ -237,7 +237,7 @@
             "name": "Prepare Body for Sub Techniques",
             "description": null,
             "arguments": {
-                "bodyParam": "{ \"mitregroups\": {{vars.groupIRI | string}},\n\"mitretactics\": {{vars.tacticIRI | string}},\n\"mitresoftware\": {{vars.softwareIRI | string}},\n\"mitretechniques\": {{vars.techniqueIRI | string}}, \n\"mitremitigations\": {{vars.mitigationIRI | string}},\"mitresubtechniques\": {{vars.subTechniqueIRI|string}}}"
+                "bodyParam": "{ \"mitregroups\": {{vars.groupIRI | string}},\n\"mitretactics\": {{vars.tacticIRI | string}},\n\"mitresoftware\": {{vars.softwareIRI | string}},\n\"mitre_techniques\": {{vars.techniqueIRI | string}}, \n\"mitremitigations\": {{vars.mitigationIRI | string}},\"mitre_sub_techniques\": {{vars.subTechniqueIRI|string}}}"
             },
             "status": null,
             "top": "570",
@@ -251,7 +251,7 @@
             "name": "Prepare Body for Techniques",
             "description": null,
             "arguments": {
-                "bodyParam": "{ \"mitregroups\": {{vars.groupIRI | string}},\n\"mitretactics\": {{vars.tacticIRI | string}},\n\"mitresoftware\": {{vars.softwareIRI | string}},\n\"mitretechniques\": {{vars.techniqueIRI | string}}, \n\"mitremitigations\": {{vars.mitigationIRI | string}}}"
+                "bodyParam": "{ \"mitregroups\": {{vars.groupIRI | string}},\n\"mitretactics\": {{vars.tacticIRI | string}},\n\"mitresoftware\": {{vars.softwareIRI | string}},\n\"mitre_techniques\": {{vars.techniqueIRI | string}}, \n\"mitremitigations\": {{vars.mitigationIRI | string}}}"
             },
             "status": null,
             "top": "570",


### PR DESCRIPTION
1311623 | Technique and Sub-Technique are not getting linked to Alert / Case Records

Description:
- Playbook [> Link ATT&CK Technique] is not able link techniques and sub-techniques 
- Fixed playbook [> Link ATT&CK Technique]  , step [Prepare Body for Techniques] 

Impact:
Techniques and sub-techniques are getting linked when added to field [Technique ID] in alert module.
Tested with private zip.
<img width="1231" height="439" alt="image" src="https://github.com/user-attachments/assets/a1d57d8f-a235-4303-87a7-165b653a40fe" />
