### PR TITLE
1311623 Fixed technique linking for case 

### DIFF
--- a/playbooks/10 - SP - MITRE ATT&CK Enrichment Framework/> Link ATT&CK Technique.json
+++ b/playbooks/10 - SP - MITRE ATT&CK Enrichment Framework/> Link ATT&CK Technique.json
@@ -237,7 +237,8 @@
             "name": "Prepare Body for Sub Techniques",
             "description": null,
             "arguments": {
-                "bodyParam": "{ \"mitregroups\": {{vars.groupIRI | string}},\n\"mitretactics\": {{vars.tacticIRI | string}},\n\"mitresoftware\": {{vars.softwareIRI | string}},\n\"mitre_techniques\": {{vars.techniqueIRI | string}}, \n\"mitremitigations\": {{vars.mitigationIRI | string}},\"mitre_sub_techniques\": {{vars.subTechniqueIRI|string}}}"
+                "bodyParam": "{ \"mitregroups\": {{vars.groupIRI | string}},\n\"mitretactics\": {{vars.tacticIRI | string}},\n\"mitresoftware\": {{vars.softwareIRI | string}},\n\"mitre_techniques\": {{vars.techniqueIRI | string}}, \n\"mitremitigations\": {{vars.mitigationIRI | string}},\"mitre_sub_techniques\": {{vars.subTechniqueIRI|string}}}",
+                "bodyParamCase": "{ \"mitregroups\": {{vars.groupIRI | string}},\n\"mitretactics\": {{vars.tacticIRI | string}},\n\"mitresoftware\": {{vars.softwareIRI | string}},\n\"mitretechniques\": {{vars.techniqueIRI | string}}, \n\"mitremitigations\": {{vars.mitigationIRI | string}},\"mitresubtechniques\": {{vars.subTechniqueIRI|string}}}"
             },
             "status": null,
             "top": "570",
@@ -251,7 +252,8 @@
             "name": "Prepare Body for Techniques",
             "description": null,
             "arguments": {
-                "bodyParam": "{ \"mitregroups\": {{vars.groupIRI | string}},\n\"mitretactics\": {{vars.tacticIRI | string}},\n\"mitresoftware\": {{vars.softwareIRI | string}},\n\"mitre_techniques\": {{vars.techniqueIRI | string}}, \n\"mitremitigations\": {{vars.mitigationIRI | string}}}"
+                "bodyParam": "{ \"mitregroups\": {{vars.groupIRI | string}},\n\"mitretactics\": {{vars.tacticIRI | string}},\n\"mitresoftware\": {{vars.softwareIRI | string}},\n\"mitre_techniques\": {{vars.techniqueIRI | string}}, \n\"mitremitigations\": {{vars.mitigationIRI | string}}}",
+                "bodyParamCase": "{ \"mitregroups\": {{vars.groupIRI | string}},\n\"mitretactics\": {{vars.tacticIRI | string}},\n\"mitresoftware\": {{vars.softwareIRI | string}},\n\"mitretechniques\": {{vars.techniqueIRI | string}}, \n\"mitremitigations\": {{vars.mitigationIRI | string}}}"
             },
             "status": null,
             "top": "570",
@@ -288,7 +290,7 @@
             "arguments": {
                 "params": {
                     "iri": "{{vars.input.records[0]['@id']}}",
-                    "body": "{{vars.bodyParam}}"
+                    "body": "{%- if vars.input.records[0][\"@type\"] == \"Alert\" -%}{{vars.bodyParam}}{%-else-%}{{vars.bodyParamCase}}{%- endif -%}"
                 },
                 "message": {
                     "tags": [],


### PR DESCRIPTION
1311623 | 
Technique and Sub-Technique are not getting linked to Alert / Case Records

Details:
- For alert and Case , Technique and subtechnique schemas are different, hence we have to write specific solutions for both instead of generalize solution. 
- 
<img width="729" height="445" alt="image" src="https://github.com/user-attachments/assets/df7868fc-fba5-4369-9c74-f662e6df7b7d" />

For case
<img width="619" height="438" alt="image" src="https://github.com/user-attachments/assets/d125d11e-4cec-48ed-9acf-b6e5dbe95eb6" />

- Added one more variable that will prepare body parameters for alert and case differently.



